### PR TITLE
Take out `normalize_before` in configs since it is unused

### DIFF
--- a/hydra_config/iwslt.yaml
+++ b/hydra_config/iwslt.yaml
@@ -11,14 +11,12 @@ model:
     ffn_embed_dim: 1024
     layers: 6
     attention_heads: 4
-    normalize_before: true
   decoder:
     embed_dim: 256
     output_dim: 256
     ffn_embed_dim: 1024
     layers: 6
     attention_heads: 4
-    normalize_before: true
   share_all_embeddings: true
   enc_res_input_norm_scale: 1.0
   dec_res_input_norm_scale: 1.0

--- a/hydra_config/opus.yaml
+++ b/hydra_config/opus.yaml
@@ -11,13 +11,11 @@ model:
     ffn_embed_dim: 2048
     layers: 18
     attention_heads: 8
-    normalize_before: true
   decoder:
     embed_dim: 512
     ffn_embed_dim: 2048
     layers: 18
     attention_heads: 8
-    normalize_before: true
   enc_alpha: 1.0
   dec_alpha: 1.0
   share_decoder_input_output_embed: true

--- a/hydra_config/wmt.yaml
+++ b/hydra_config/wmt.yaml
@@ -11,14 +11,12 @@ model:
     ffn_embed_dim: 2048
     layers: 6
     attention_heads: 8
-    normalize_before: true
   decoder:
     embed_dim: 512
     output_dim: 512
     ffn_embed_dim: 2048
     layers: 6
     attention_heads: 8
-    normalize_before: true
   share_all_embeddings: true
   base_layers: 0
 


### PR DESCRIPTION
The `normalize_before` flag is not implemented for the `resi_dual` architecture, taking it out of the configs to avoid confusion since the intra-layers use PostLN.